### PR TITLE
Revert "Update to serposcope 2.7.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
       rm -rf /tmp/* && \
       rm -rf /var/tmp/*
 
-ENV SERPOSCOPE_VERSION 2.7.0
+ENV SERPOSCOPE_VERSION 2.6.0
 
 RUN mkdir -p /opt/serposcope /var/log/serposcope /var/lib/serposcope/
 RUN curl -L https://serposcope.serphacker.com/download/${SERPOSCOPE_VERSION}/serposcope-${SERPOSCOPE_VERSION}.jar > /opt/serposcope.jar


### PR DESCRIPTION
Reverts fr3nd/docker-serposcope#3

The jar file is still not available to download