### PR TITLE
Release serposcope 2.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y \
       rm -rf /tmp/* && \
       rm -rf /var/tmp/*
 
-ENV SERPOSCOPE_VERSION 2.6.0
+ENV SERPOSCOPE_VERSION 2.7.1
 
 RUN mkdir -p /opt/serposcope /var/log/serposcope /var/lib/serposcope/
 RUN curl -L https://serposcope.serphacker.com/download/${SERPOSCOPE_VERSION}/serposcope-${SERPOSCOPE_VERSION}.jar > /opt/serposcope.jar


### PR DESCRIPTION
Serposcope released [2.7.1](https://github.com/serphacker/serposcope/releases/tag/v2.7.1) that's is avaialble as [official package](https://serposcope.serphacker.com/download/)